### PR TITLE
Load configuration with default values when the format is invalid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "lsfg-vk-ui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "directories",
  "dirs",

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct GlobalConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct GameProfile {
     pub exe: String,
     pub multiplier: u32,
@@ -95,8 +96,17 @@ pub fn load_config() -> Result<Config, io::Error> {
     if config_path.exists() {
         let contents = fs::read_to_string(&config_path)?;
         println!("Successfully read config contents ({} bytes).", contents.len());
-        let mut config: Config = toml::from_str(&contents)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to parse TOML: {}", e)))?;
+        // Load configuration with default values when the format is invalid
+        let mut config: Config = toml::from_str(&contents).unwrap_or_else(|_| Config::default());
+
+        // Old way to load config
+        // let mut config: Config = toml::from_str(&contents).map_err(|e| {
+        //     io::Error::new(
+        //         io::ErrorKind::InvalidData,
+        //         format!("Failed to parse TOML: {}", e),
+        //     )
+        // })?;
+
         
         // Clean up any floating point precision issues in existing configs
         let mut needs_save = false;


### PR DESCRIPTION
Load existing configuration
![](https://cdn.discordapp.com/attachments/1097763876260552714/1396598863858761738/screenshot6.png?ex=687eab8c&is=687d5a0c&hm=ccbb04cfd8985f38b36a36a8c0c7e4a335e2f2909ad46d64a0dc4f75c17d380b)